### PR TITLE
fix: update advance example to remove the metrics router settings

### DIFF
--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -101,13 +101,13 @@ module "metrics_routing" {
     }
   ]
 
-  /* 
+  /*
 
   ##############################################################################
   # - Global Metrics Routing configuration
   ##############################################################################
 
-  This block shows how to configure global metrics routing settings. 
+  This block shows how to configure global metrics routing settings.
   Removing this since it is causing intermittent failure in the pipeline as shown in https://github.ibm.com/GoldenEye/issues/issues/12223
 
   metrics_router_settings = {

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -101,9 +101,14 @@ module "metrics_routing" {
     }
   ]
 
+  /* 
+
   ##############################################################################
   # - Global Metrics Routing configuration
   ##############################################################################
+
+  This block shows how to configure global metrics routing settings. 
+  Removing this since it is causing intermittent failure in the pipeline as shown in https://github.ibm.com/GoldenEye/issues/issues/12223
 
   metrics_router_settings = {
     default_targets = [{
@@ -113,4 +118,5 @@ module "metrics_routing" {
     primary_metadata_region   = var.region
     private_api_endpoint_only = false
   }
+  */
 }

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -167,7 +167,7 @@ func TestRunUpgradeFullyConfigurable(t *testing.T) {
 	t.Parallel()
 
 	var region = validRegions[rand.Intn(len(validRegions))]
-	prefix := "icm-da-upg"
+	prefix := fmt.Sprintf("icm-da-upg-%s", strings.ToLower(random.UniqueId()))
 
 	// ------------------------------------------------------------------------------------
 	// Provision Cloud Monitoring
@@ -175,7 +175,7 @@ func TestRunUpgradeFullyConfigurable(t *testing.T) {
 
 	var preReqDir = "./existing-resources"
 	realTerraformDir := preReqDir
-	tempTerraformDir, _ := files.CopyTerraformFolderToTemp(realTerraformDir, fmt.Sprintf(prefix+"-%s", strings.ToLower(random.UniqueId())))
+	tempTerraformDir, _ := files.CopyTerraformFolderToTemp(realTerraformDir, prefix)
 	tags := common.GetTagsFromTravis()
 
 	// Verify ibmcloud_api_key variable is set

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -39,13 +39,6 @@ var validRegions = []string{
 	"us-east",
 }
 
-func truncate(prefix string, max int) string {
-	if len(prefix) > max {
-		return prefix[:max]
-	}
-	return prefix
-}
-
 func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptions {
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
 		Testing:       t,
@@ -174,7 +167,11 @@ func TestRunUpgradeFullyConfigurable(t *testing.T) {
 	t.Parallel()
 
 	var region = validRegions[rand.Intn(len(validRegions))]
-	prefix := truncate(fmt.Sprintf("icm-da-upg-%s", strings.ToLower(random.UniqueId())), 16)
+	prefix := fmt.Sprintf("icm-da-upg-%s", strings.ToLower(random.UniqueId()))
+
+	if len(prefix) > 16 {
+		prefix = prefix[:16]
+	}
 
 	// ------------------------------------------------------------------------------------
 	// Provision Cloud Monitoring

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -167,11 +167,7 @@ func TestRunUpgradeFullyConfigurable(t *testing.T) {
 	t.Parallel()
 
 	var region = validRegions[rand.Intn(len(validRegions))]
-	prefix := fmt.Sprintf("icm-da-upg-%s", strings.ToLower(random.UniqueId()))
-
-	if len(prefix) > 16 {
-		prefix = prefix[:16]
-	}
+	prefix := fmt.Sprintf("icm-da-up-%s", strings.ToLower(random.UniqueId()))
 
 	// ------------------------------------------------------------------------------------
 	// Provision Cloud Monitoring

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -39,6 +39,13 @@ var validRegions = []string{
 	"us-east",
 }
 
+func truncate(prefix string, max int) string {
+	if len(prefix) > max {
+		return prefix[:max]
+	}
+	return prefix
+}
+
 func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptions {
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
 		Testing:       t,
@@ -167,7 +174,7 @@ func TestRunUpgradeFullyConfigurable(t *testing.T) {
 	t.Parallel()
 
 	var region = validRegions[rand.Intn(len(validRegions))]
-	prefix := fmt.Sprintf("icm-da-upg-%s", strings.ToLower(random.UniqueId()))
+	prefix := truncate(fmt.Sprintf("icm-da-upg-%s", strings.ToLower(random.UniqueId())), 16)
 
 	// ------------------------------------------------------------------------------------
 	// Provision Cloud Monitoring

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -62,8 +62,7 @@ func TestRunBasicExample(t *testing.T) {
 }
 
 func TestRunAdvancedExampleInSchematics(t *testing.T) {
-	// https://github.ibm.com/GoldenEye/issues/issues/12223
-	// Avoid t.Parallel() to avoid test clashes
+	t.Parallel()
 
 	var region = validRegions[rand.Intn(len(validRegions))]
 
@@ -94,8 +93,7 @@ func TestRunAdvancedExampleInSchematics(t *testing.T) {
 
 // Upgrade test in schematics (using advanced example)
 func TestRunUpgradeExampleInSchematics(t *testing.T) {
-	// https://github.ibm.com/GoldenEye/issues/issues/12223
-	// Avoid t.Parallel() to avoid test clashes
+	t.Parallel()
 
 	var region = validRegions[rand.Intn(len(validRegions))]
 

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -167,7 +167,7 @@ func TestRunUpgradeFullyConfigurable(t *testing.T) {
 	t.Parallel()
 
 	var region = validRegions[rand.Intn(len(validRegions))]
-	prefix := fmt.Sprintf("icm-da-upg-%s", strings.ToLower(random.UniqueId()))
+	prefix := "icm-da-upg"
 
 	// ------------------------------------------------------------------------------------
 	// Provision Cloud Monitoring


### PR DESCRIPTION
### Description

Removing the metrics router setting part from the advanced example as it is causing intermittent pipeline failure.

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
