### PR TITLE
Place `enable_metrics_routing_to_cloud_monitoring` in required tab

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -202,6 +202,10 @@
               "required": true
             },
             {
+              "key": "enable_metrics_routing_to_cloud_monitoring",
+              "required": true
+            },
+            {
               "key": "existing_cloud_monitoring_crn",
               "value_constraints": [
                 {
@@ -210,9 +214,6 @@
                   "value": "^__NULL__$|^crn:(.*:){3}sysdig-monitor:(.*:){2}[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}::$"
                 }
               ]
-            },
-            {
-              "key": "enable_metrics_routing_to_cloud_monitoring"
             },
             {
               "key": "enable_primary_metadata_region"


### PR DESCRIPTION
### Description

The `enable_metrics_routing_to_cloud_monitoring` input is the new way to enable platform metrics, so marking it as required and putting it beside the `enable_platform_metrics` input. Eventually the `enable_platform_metrics` input will be removed once the service deprecates it.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
