### PR TITLE
chore: update tag descriptions and add access_tag dependencies

### DIFF
--- a/examples/advanced/variables.tf
+++ b/examples/advanced/variables.tf
@@ -28,12 +28,16 @@ variable "region" {
 
 variable "resource_tags" {
   type        = list(string)
-  description = "Tags associated with the IBM Cloud Monitoring instance (Optional, array of strings)."
+  description = "Add user resource tags to the cloud-monitoring instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)"
+  validation {
+    condition     = alltrue([for tag in var.resource_tags : can(regex("^[A-Za-z0-9 _\\-.:]{1,128}$", tag))])
+    error_message = "Each resource tag must be 128 characters or less and may contain only A-Z, a-z, 0-9, spaces, underscore (_), hyphen (-), period (.), and colon (:)."
+  }
   default     = []
 }
 
 variable "access_tags" {
   type        = list(string)
-  description = "Access Management Tags associated with the IBM Cloud Monitoring instance (Optional, array of strings)."
+  description = "Add access management tags to the cloud-monitoring instance to control access. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)"
   default     = []
 }

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -34,6 +34,10 @@ variable "resource_group" {
 
 variable "resource_tags" {
   type        = list(string)
-  description = "List of resource tag to associate with all resource instances created by this example."
+  description = "Add user resource tags to the cloud-monitoring instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)"
+  validation {
+    condition     = alltrue([for tag in var.resource_tags : can(regex("^[A-Za-z0-9 _\\-.:]{1,128}$", tag))])
+    error_message = "Each resource tag must be 128 characters or less and may contain only A-Z, a-z, 0-9, spaces, underscore (_), hyphen (-), period (.), and colon (:)."
+  }
   default     = []
 }

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,13 @@ resource "ibm_resource_instance" "cloud_monitoring" {
   }
 }
 
+data "ibm_iam_access_tag" "access_tag" {
+  for_each = length(var.access_tags) != 0 ? toset(var.access_tags) : []
+  name     = each.value
+}
+
 resource "ibm_resource_tag" "cloud_monitoring_tag" {
+  depends_on = [data.ibm_iam_access_tag.access_tag]
   count       = length(var.access_tags) == 0 ? 0 : 1
   resource_id = ibm_resource_instance.cloud_monitoring.crn
   tags        = var.access_tags

--- a/tests/existing-resources/variables.tf
+++ b/tests/existing-resources/variables.tf
@@ -20,6 +20,10 @@ variable "prefix" {
 
 variable "resource_tags" {
   type        = list(string)
-  description = "Optional list of tags to be added to created resources"
+  description = "Add user resource tags to the cloud-monitoring instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)"
+  validation {
+    condition     = alltrue([for tag in var.resource_tags : can(regex("^[A-Za-z0-9 _\\-.:]{1,128}$", tag))])
+    error_message = "Each resource tag must be 128 characters or less and may contain only A-Z, a-z, 0-9, spaces, underscore (_), hyphen (-), period (.), and colon (:)."
+  }
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -77,13 +77,17 @@ variable "resource_keys" {
 
 variable "resource_tags" {
   type        = list(string)
-  description = "Tags associated with the IBM Cloud Monitoring instance (Optional, array of strings)."
+  description = "Add user resource tags to the cloud-monitoring instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)"
+  validation {
+    condition     = alltrue([for tag in var.resource_tags : can(regex("^[A-Za-z0-9 _\\-.:]{1,128}$", tag))])
+    error_message = "Each resource tag must be 128 characters or less and may contain only A-Z, a-z, 0-9, spaces, underscore (_), hyphen (-), period (.), and colon (:)."
+  }
   default     = []
 }
 
 variable "access_tags" {
   type        = list(string)
-  description = "Access Management Tags associated with the IBM Cloud Monitoring instance (Optional, array of strings)."
+  description = "Add access management tags to the cloud-monitoring instance to control access. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)"
   default     = []
 }
 


### PR DESCRIPTION
This PR updates:
- resource_tags variable description and validation
- access_tags variable description
- Adds data block for ibm_iam_access_tag
- Adds depends_on to ibm_resource_tag resources with tag_type='access'